### PR TITLE
Add "Hello World!" unit tests for SkipList using catch2 framework

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "gbbs/parlaylib"]
 	path = gbbs/parlaylib
 	url = git@github.com:cmuparlay/parlaylib.git
+[submodule "catch2"]
+	path = catch2
+	url = git@github.com:catchorg/Catch2.git

--- a/gbbs/benchmarks/BatchDynamicConnectivity/SkipList/SkipList.h
+++ b/gbbs/benchmarks/BatchDynamicConnectivity/SkipList/SkipList.h
@@ -525,6 +525,17 @@ struct SkipList {
     }
 };
 
+bool operator == ( SkipList const& list1, SkipList const& list2 )
+{
+    return list1.n == list2.n;
+}
+
+std::ostream & operator << ( std::ostream & s, SkipList const& skiplist )
+{
+    s << "SkipList( n = " << skiplist.n << " )";
+    return s;
+}
+
 sequence<sequence<std::pair<uintE, uintE>>> default_values(uintE a, uintE b) {
         auto values_seq = sequence<sequence<std::pair<uintE, uintE>>>(2, sequence<std::pair<uintE, uintE>>(
                     ceil(log(10)/log(2)),

--- a/gbbs/benchmarks/BatchDynamicConnectivity/SkipList/TestSkipList.cc
+++ b/gbbs/benchmarks/BatchDynamicConnectivity/SkipList/TestSkipList.cc
@@ -1,5 +1,8 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
-#include "../../../../catch2/single_include/catch2/catch.hpp"
+
+#include "benchmarks/BatchDynamicConnectivity/SkipList/SkipList.h"
+#include "single_include/catch2/catch.hpp"
+
 
 unsigned int Factorial( unsigned int number ) {
     return number <= 1 ? number : Factorial(number-1)*number;

--- a/gbbs/benchmarks/BatchDynamicConnectivity/SkipList/TestSkipList.cc
+++ b/gbbs/benchmarks/BatchDynamicConnectivity/SkipList/TestSkipList.cc
@@ -3,15 +3,19 @@
 #include "benchmarks/BatchDynamicConnectivity/SkipList/SkipList.h"
 #include "single_include/catch2/catch.hpp"
 
+TEST_CASE( "Equality operator == matches two empty skiplists", "[skiplist][equality]" )
+{
+    gbbs::SkipList default_constructed_list;
+    gbbs::SkipList zero_initialised_list(0);
 
-unsigned int Factorial( unsigned int number ) {
-    return number <= 1 ? number : Factorial(number-1)*number;
+    REQUIRE( default_constructed_list == zero_initialised_list );
 }
 
-TEST_CASE( "Factorials are computed", "[factorial]" ) {
-    REQUIRE( Factorial(0) == 1 );
-    REQUIRE( Factorial(1) == 1 );
-    REQUIRE( Factorial(2) == 2 );
-    REQUIRE( Factorial(3) == 6 );
-    REQUIRE( Factorial(10) == 3628800 );
+TEST_CASE( "Equality operator == failes with just one empty skiplist", "[skiplist][equality]" )
+{
+    gbbs::SkipList default_constructed_list;
+    gbbs::SkipList zero_initialised_list(42);
+
+    REQUIRE( default_constructed_list == zero_initialised_list );
 }
+

--- a/gbbs/benchmarks/BatchDynamicConnectivity/SkipList/makefile
+++ b/gbbs/benchmarks/BatchDynamicConnectivity/SkipList/makefile
@@ -3,7 +3,8 @@ ROOTDIR = $(strip $(shell git rev-parse --show-cdup))
 
 include $(ROOTDIR)gbbs/makefile.variables
 
-ALL= SkipList TestSkipList
+ALL= SkipList
+TEST= TestSkipList
 
 include $(ROOTDIR)gbbs/benchmarks/makefile.benchmarks
 

--- a/gbbs/benchmarks/BatchDynamicConnectivity/SkipList/makefile
+++ b/gbbs/benchmarks/BatchDynamicConnectivity/SkipList/makefile
@@ -3,7 +3,7 @@ ROOTDIR = $(strip $(shell git rev-parse --show-cdup))
 
 include $(ROOTDIR)gbbs/makefile.variables
 
-ALL= SkipList
+ALL= SkipList TestSkipList
 
 include $(ROOTDIR)gbbs/benchmarks/makefile.benchmarks
 

--- a/gbbs/benchmarks/BatchDynamicConnectivity/TestSkipList/TestSkipList.cpp
+++ b/gbbs/benchmarks/BatchDynamicConnectivity/TestSkipList/TestSkipList.cpp
@@ -1,0 +1,14 @@
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#include "../../../../catch2/single_include/catch2/catch.hpp"
+
+unsigned int Factorial( unsigned int number ) {
+    return number <= 1 ? number : Factorial(number-1)*number;
+}
+
+TEST_CASE( "Factorials are computed", "[factorial]" ) {
+    REQUIRE( Factorial(0) == 1 );
+    REQUIRE( Factorial(1) == 1 );
+    REQUIRE( Factorial(2) == 2 );
+    REQUIRE( Factorial(3) == 6 );
+    REQUIRE( Factorial(10) == 3628800 );
+}

--- a/gbbs/benchmarks/BatchDynamicConnectivity/TestSkipList/makefile
+++ b/gbbs/benchmarks/BatchDynamicConnectivity/TestSkipList/makefile
@@ -1,0 +1,9 @@
+# git root directory
+ROOTDIR = $(strip $(shell git rev-parse --show-cdup))
+
+include $(ROOTDIR)gbbs/makefile.variables
+CFLAGS += -I$(ROOTDIR)catch2/single_include/
+
+ALL= TestSkipList
+
+include $(ROOTDIR)gbbs/benchmarks/makefile.benchmarks

--- a/gbbs/benchmarks/BatchDynamicConnectivity/TestSkipList/makefile
+++ b/gbbs/benchmarks/BatchDynamicConnectivity/TestSkipList/makefile
@@ -1,9 +1,0 @@
-# git root directory
-ROOTDIR = $(strip $(shell git rev-parse --show-cdup))
-
-include $(ROOTDIR)gbbs/makefile.variables
-CFLAGS += -I$(ROOTDIR)catch2/single_include/
-
-ALL= TestSkipList
-
-include $(ROOTDIR)gbbs/benchmarks/makefile.benchmarks

--- a/gbbs/benchmarks/makefile.benchmarks
+++ b/gbbs/benchmarks/makefile.benchmarks
@@ -1,4 +1,4 @@
-INCLUDE_DIRS = -I$(ROOTDIR)gbbs/ -I$(ROOTDIR)gbbs/parlaylib/include/
+INCLUDE_DIRS = -I$(ROOTDIR)gbbs/ -I$(ROOTDIR)gbbs/parlaylib/include/ -I$(ROOTDIR)catch2/
 
 .DEFAULT_GOAL := all
 

--- a/gbbs/benchmarks/makefile.benchmarks
+++ b/gbbs/benchmarks/makefile.benchmarks
@@ -2,6 +2,7 @@ INCLUDE_DIRS = -I$(ROOTDIR)gbbs/ -I$(ROOTDIR)gbbs/parlaylib/include/ -I$(ROOTDIR
 
 .DEFAULT_GOAL := all
 
+test: $(all) $(TEST)
 all: $(ALL)
 
 LIGRA_OBJS = $(wildcard $(ROOTDIR)gbbs/bin/gbbs/*.a)
@@ -32,4 +33,4 @@ gbbs_encodings :
 .PHONY : clean
 
 clean :
-	rm -f *.o $(ALL) $(ALL_OBJS) $(ALL_OBJS_CLEAN)
+	rm -f *.o $(ALL) $(TEST) $(ALL_OBJS) $(ALL_OBJS_CLEAN)


### PR DESCRIPTION
_Adds catch as a submodule, modifies build to optionally build a unit tests executable for SkipList, and adds two sample unit tests_

### Overview

We need to build up some unit tests for the `BatchDynamicConnectivity` benchmark. This PR is a first step in that direction, getting the framework set up to test `SkipList`. Major changes include:
  * [Catch2](https://github.com/catchorg/Catch2) is added as a git submodule in the root directory, i.e., outside `gbbs`. We captured the `v2.x` branch of catch because, for now at least, I am favouring the simplicity of the single-include header file version, not the version 3 bazel-based build
  * A new source file was added to `gbbs/benchmarks/BatchDynamicConnectivity/SkipList` called `TestSkipList.cc`. This file contains all the catch unit tests for `SkipList.h`. Currently, it has been populated with only two small 'hello world' style tests that just check if two skip lists have the same length
  * The `SkipList` interface was modified to include two operator overloads: `==` and `<<`.  These are to facilitate easier unit testing, as the built-in assert() uses the `==` operator and the string expansion of objects in the case of  failed assertion uses the `<<` operator. These are probably not implemented correctly as they do not look at individual list elements so fixing them is a TODO. They are implemented outside the class because they do not rely on any private member variables.
  * The makefiles were modified so that `SkipList` now has a new target, `test`, that builds the unit tests instead of the cpp file.