### PR TITLE
Add unit tests for update_top_down function in SkipList

### DIFF
--- a/gbbs/benchmarks/BatchDynamicConnectivity/SkipList/TestSkipList.cc
+++ b/gbbs/benchmarks/BatchDynamicConnectivity/SkipList/TestSkipList.cc
@@ -3,19 +3,169 @@
 #include "benchmarks/BatchDynamicConnectivity/SkipList/SkipList.h"
 #include "single_include/catch2/catch.hpp"
 
-TEST_CASE( "Equality operator == matches two empty skiplists", "[skiplist][equality]" )
-{
-    gbbs::SkipList default_constructed_list;
-    gbbs::SkipList zero_initialised_list(0);
+int max_length_for_bottom_level=10;
 
-    REQUIRE( default_constructed_list == zero_initialised_list );
+void initialize_skiplist_for_tests(gbbs::SkipList & skip_list,parlay::sequence<gbbs::SkipList::SkipListElement> &skip_list_elements){
+    //Create ndoes and assign integer values to their values array. 
+    for (int i=0; i<max_length_for_bottom_level; i++){
+        skip_list_elements[i] = skip_list.create_node(i, nullptr, nullptr, gbbs::default_values(i,i));
+        skip_list_elements[i].update_level=0;
+        skip_list.update_top_down(skip_list_elements[i].height-1,&skip_list_elements[i]);
+    }
+
+    for(int i=0; i<max_length_for_bottom_level-1; i++){
+        skip_list.join(&skip_list_elements[i], &skip_list_elements[i+1]);
+    }
 }
 
-TEST_CASE( "Equality operator == failes with just one empty skiplist", "[skiplist][equality]" )
+TEST_CASE("Unit tests for update_top_down","SkipList")
 {
-    gbbs::SkipList default_constructed_list;
-    gbbs::SkipList zero_initialised_list(42);
+    auto skip_list = gbbs::SkipList(max_length_for_bottom_level);
+    parlay::sequence<gbbs::SkipList::SkipListElement> skip_list_elements = parlay::sequence<gbbs::SkipList::SkipListElement>(max_length_for_bottom_level);
+    initialize_skiplist_for_tests(skip_list,skip_list_elements);
 
-    REQUIRE( default_constructed_list == zero_initialised_list );
+    //Test if assigned actual values instead of zeros to the values arraies
+    SECTION("Test the correctness of initialization!"){
+        for(int i=0; i<max_length_for_bottom_level; i++){
+            gbbs::SkipList::values_array expected_value_arr = gbbs::default_values_array(skip_list_elements[i].height,i,i);
+            for(int j=1; j<expected_value_arr.size();j++){expected_value_arr[j]=expected_value_arr[0];}
+            REQUIRE(skip_list_elements[i].values == expected_value_arr);
+        }
+    }
+
+    SECTION("Level = 0 || Number of children =0"){
+        for(int i=0; i<max_length_for_bottom_level; i++){
+            ////The location within the skiplist for this test case, which means all nodes with height = 1
+            if(skip_list_elements[i].height==1){
+                skip_list_elements[i].values[0]=gbbs::default_values(i+1,i+1);//Make a change to the value of the element being tested
+                skip_list.update_top_down(skip_list_elements[i].height-1, &skip_list_elements[i]);
+                gbbs::SkipList::values_array expected_value_arr = gbbs::default_values_array(skip_list_elements[i].height,i+1,i+1);
+                REQUIRE(skip_list_elements[i].values == expected_value_arr);
+            }
+        }
+    }
+
+    SECTION("Level = 3 which is Max_height-1"){
+        //The location within the skiplist for this test case, which is the seventh node in the skiplist
+        int loc = 7;
+        skip_list_elements[loc].values[0]=gbbs::default_values(loc+1,loc+1);//Make a change to the value of the element being tested
+        gbbs::SkipList::values_array expected_value_arr = gbbs::default_values_array(skip_list_elements[loc].height,loc,loc);
+        for(int j=1; j<expected_value_arr.size();j++){expected_value_arr[j]=expected_value_arr[0];}
+        expected_value_arr[0]=skip_list_elements[loc].values[0];
+
+        SECTION("Number of children = 1"){
+            skip_list.split(&skip_list_elements[loc]);//Break the following chain to prevent more children 
+            
+            SECTION("Recursive spawn: no"){
+                skip_list.update_top_down(skip_list_elements[loc].height-1, &skip_list_elements[loc]);
+                REQUIRE(skip_list_elements[loc].values == expected_value_arr);
+            }
+
+            SECTION("Recursive spawn: only for the top two levels of the element"){
+                skip_list_elements[loc].update_level=skip_list_elements[loc].height-2;//Set ONLY top 2 levels of this element to be updated, which should produce the same result as the case above
+                skip_list.update_top_down(skip_list_elements[loc].height-1, &skip_list_elements[loc]);
+                REQUIRE(skip_list_elements[loc].values == expected_value_arr);
+            }
+
+            SECTION("Recursive spawn: all over the element"){
+                skip_list_elements[loc].update_level=0;//Set all levels of this element to be updated
+                skip_list.update_top_down(skip_list_elements[loc].height-1, &skip_list_elements[loc]);
+                for(int j=1; j<expected_value_arr.size();j++){expected_value_arr[j]=expected_value_arr[0];}
+                REQUIRE(skip_list_elements[loc].values == expected_value_arr);
+            }
+        }
+
+        SECTION("Number of children = N"){
+            expected_value_arr[3]=gbbs::XOR_function(skip_list_elements[loc].values[2],skip_list_elements[loc+1].values[2]);
+
+            SECTION("Recursive spawn: no"){//Should only update the value for the top level
+                skip_list.update_top_down(skip_list_elements[loc].height-1, &skip_list_elements[loc]);
+                REQUIRE(skip_list_elements[loc].values == expected_value_arr);
+            }
+
+            SECTION("Recursive spawn: only for the top two levels of the element"){
+                skip_list_elements[loc].update_level=skip_list_elements[loc].height-2;//Set ONLY top 2 levels of this element to be updated, which should produce the same result as the case above
+                skip_list.update_top_down(skip_list_elements[loc].height-1, &skip_list_elements[loc]);
+                REQUIRE(skip_list_elements[loc].values == expected_value_arr);
+            }
+
+            SECTION("Recursive spawn: all over the element"){
+                skip_list_elements[loc].update_level=0;//Set all levels of this element to be updated
+                skip_list.update_top_down(skip_list_elements[loc].height-1, &skip_list_elements[loc]);
+
+                expected_value_arr[0]=skip_list_elements[loc].values[0];
+                for(int j=1; j<expected_value_arr.size()-1;j++){expected_value_arr[j]=expected_value_arr[0];}
+                expected_value_arr[3]=gbbs::XOR_function(skip_list_elements[loc].values[2],skip_list_elements[loc+1].values[2]);
+                REQUIRE(skip_list_elements[loc].values == expected_value_arr);
+            }
+        }
+    }
+
+    SECTION("Level = 2 which is between 0 and Max_height-1"){
+        int loc = 8;
+        skip_list_elements[loc].values[0]=gbbs::default_values(loc+1,loc+1);
+        gbbs::SkipList::values_array expected_value_arr = gbbs::default_values_array(skip_list_elements[loc].height,loc,loc);
+
+        SECTION("Number of children = N"){
+            SECTION("No loop exist in the SkipList"){
+                for(int j=1; j<expected_value_arr.size();j++){expected_value_arr[j]=expected_value_arr[0];}
+                expected_value_arr[0]=skip_list_elements[loc].values[0];
+                expected_value_arr[2]=gbbs::XOR_function(skip_list_elements[loc].values[1],skip_list_elements[loc+1].values[1]);
+
+                SECTION("Recursive spawn: no"){
+                    skip_list.update_top_down(skip_list_elements[loc].height-1, &skip_list_elements[loc]);
+                    REQUIRE(skip_list_elements[loc].values == expected_value_arr);
+                }
+
+                expected_value_arr[1]=skip_list_elements[loc].values[0];
+                expected_value_arr[2]=gbbs::XOR_function(expected_value_arr[1],skip_list_elements[loc+1].values[1]);
+
+                SECTION("Recursive spawn: only for the top two levels of the element"){
+                    skip_list_elements[loc].update_level=skip_list_elements[loc].height-2;//Set ONLY top 2 levels of this element to be updated, which means all levels for this element as the case below
+                    skip_list.update_top_down(skip_list_elements[loc].height-1, &skip_list_elements[loc]);
+                    REQUIRE(skip_list_elements[loc].values == expected_value_arr);
+                }
+
+                SECTION("Recursive spawn: all over the element"){
+                    skip_list_elements[loc].update_level=0;//Set all levels of this element to be updated, which should produce the same result as the case above
+                    skip_list.update_top_down(skip_list_elements[loc].height-1, &skip_list_elements[loc]);
+                    REQUIRE(skip_list_elements[loc].values == expected_value_arr);
+                }
+            }
+
+            SECTION("Loop exist in the SkipList"){
+                skip_list.join(&skip_list_elements[max_length_for_bottom_level-1],&skip_list_elements[0]);
+
+                expected_value_arr[0]=skip_list_elements[loc].values[0];
+                expected_value_arr[1]=gbbs::default_values(loc,loc);
+                expected_value_arr[2]=gbbs::XOR_function(expected_value_arr[1],skip_list_elements[9].values[1]);
+                expected_value_arr[2]=gbbs::XOR_function(expected_value_arr[2],skip_list_elements[1].values[1]);
+                expected_value_arr[2]=gbbs::XOR_function(expected_value_arr[2],skip_list_elements[4].values[1]);
+                expected_value_arr[2]=gbbs::XOR_function(expected_value_arr[2],skip_list_elements[6].values[1]);
+    
+                SECTION("Recursive spawn: no"){
+                    skip_list.update_top_down(skip_list_elements[loc].height-1, &skip_list_elements[loc]);
+                    REQUIRE(skip_list_elements[loc].values == expected_value_arr);
+                }
+
+                expected_value_arr[1]=skip_list_elements[loc].values[0];
+                expected_value_arr[2]=gbbs::XOR_function(expected_value_arr[1],skip_list_elements[9].values[1]);
+                expected_value_arr[2]=gbbs::XOR_function(expected_value_arr[2],skip_list_elements[1].values[1]);
+                expected_value_arr[2]=gbbs::XOR_function(expected_value_arr[2],skip_list_elements[4].values[1]);
+                expected_value_arr[2]=gbbs::XOR_function(expected_value_arr[2],skip_list_elements[6].values[1]);
+
+                SECTION("Recursive spawn: only for the top two levels of the element"){
+                    skip_list_elements[loc].update_level=skip_list_elements[loc].height-2;//Set ONLY top 2 levels of this element to be updated, which means all levels for this element
+                    skip_list.update_top_down(skip_list_elements[loc].height-1, &skip_list_elements[loc]);
+                    REQUIRE(skip_list_elements[loc].values == expected_value_arr);
+                }
+
+                SECTION("Recursive spawn: all over the element"){
+                    skip_list_elements[loc].update_level=0;//Set all levels of this element to be updated, which should produce the same result as the case above
+                    skip_list.update_top_down(skip_list_elements[loc].height-1, &skip_list_elements[loc]);
+                    REQUIRE(skip_list_elements[loc].values == expected_value_arr);
+                }
+            }
+        }
+    }
 }
-


### PR DESCRIPTION
### **Pull Request Description:**

This pull request adds unit tests for the update_top_down function in the SkipList class. The tests cover various scenarios to ensure the correctness and robustness of the function implementation.

This pull request also adds the helper functions implemented within the SkipList.h. These functions, including the printing out of values_array and the skiplist, as well as the overload of operator "==," aim at making the testing easier and more clear.

**Please note:** 

Although all tests have passed successfully on my laptop, there is a lingering concern. Dr. Liu previously remarked that there may be issues with the update_top_down function, stating it as "buggy." However, the function appears to operate smoothly during testing. (It it also possible that, she was actually talking about the "batch_update function", and my memory has gotten blur.)

### **Scope of Test Cases**
- Initialization Validation: Ensures correct initialization of the values array.
- Handling Different Element Heights:
  - Elements with height 0.
  - Elements with maximum height within the SkipList.
  - Elements with intermediate heights.
- Handling elements with different number of children.
  - Elements with no children.
  - Elements with a single child.
  - Elements with multiple children. (No cycle exist.)
  - Elements with multiple children. (Cycle exists in the SkipList.) 
- Recursive Spawning Variations:
  - No recursive spawning.
  - Partial recursive spawning limited to specific levels.
  - Recursive spawning across all levels of the element.

Certain test case combinations are omitted as they lack meaningfulness. For instance, elements with height 1 cannot have multiple children, thus corresponding test cases are redundant.

### **Code Logic Explanation:**

**1. SkipList Setup:**

  Initialization of a SkipList with a length of 10, assigning each element an initial value based on its index. The height of each element is randomly determined within the SkipList.

**2. Initialization and Initial Values Testing:** 

  Update_top_down function is first invoked to ensure uniformity across all levels of the values array for any individual element. Subsequently, the "Test the correctness of initialization!" case confirms the desired values array state.

   The reason behind this practice is, the default values arrays are all zeros except for the bottom level, which dramatically increases the chances of fake passing, since 0 xor X = X. (Hard to debug with all zeros.)

**3. Nested sections of test cases.** 

  Test cases are organized in nested layers to maintain logical clarity. The outermost layer addresses element heights, followed by number of children, and lastly, recursive spawning levels.

  Testing for loops only considers scenarios where elements have multiple children and a height of 2. Testing at higher levels will be the same as 1 (which means a height of 2) , and testing at the bottom level makes no sense since the bottom nodes only take themselves into account.  

### **Explanation for the modifications to SkipList.h:**

1. Line 15-26: Relocate variable type declarations from within the "SkipListElement" class to the encompassing "SkipList" class for improved accessibility.

2. Line 66-67: Initialize the pointers for newly created skip_list_elements to nullptr to preempt memory-related issues during runtime.

3. Line 514-525: Overload the "==" operator for "values_array" to simplify testing.

4. Line 535-549: A function that construct the default values_array based on a given initial value.

5. Line 551-560: A function that takes the XOR for two values_array_for_one_level. 

6. Line 819-857: Two functions that overload the "<<" operator, to print our values_array and the skiplist nodes. 



